### PR TITLE
Remove subtitle line from landing header

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,6 @@
         <svg width="40" height="40" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 2l3 6 6 .9-4.5 4.3 1 6-5.5-3-5.5 3 1-6L3 8.9 9 8l3-6z" fill="#2563eb"/></svg>
         <div>
           <h1>Shloka’s Futuristic Tech & Career Portal</h1>
-          <div class="subtitle">For an MPC student in Hyderabad aiming at AI-heavy, Robotics, Semiconductor/Embedded, and Clean-Tech careers.</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the subtitle referencing MPC student in Hyderabad from the landing page header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5e8c3aa2c832194350848be85ab36