### PR TITLE
Add IIM Bangalore UG programmes to portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,12 @@ const trends = [
     core:["DSA","Probability & stats","Numerics","Optimization","Systems & ML foundations"],
     fit:"Perfect for analytical thinkers who love proofs, coding challenges, and translating real problems into equations."
   },
+  { id:"econ-ds", name:"Economics, Data & Business Studies",
+    overview:"Economics + Data Science at IIMB blends quantitative reasoning, policy thinking and business context. You learn to read markets, model data, and make evidence-backed decisions that organisations trust.",
+    apps:["Economic analysis","Data-driven policy","Business analytics","Financial markets","Product/strategy"],
+    core:["Math/stats for decisions","Micro & macroeconomics","Data science & coding","Research methods","Business studies"],
+    fit:"Great for students who like numbers, current affairs and translating data into clear recommendations."
+  },
   { id:"design", name:"Design & Human-Centred Innovation",
     overview:"Design blends creativity with problem-solving to craft products, interfaces and services people love. You’ll explore visual communication, physical products and digital experiences with empathy-driven research.",
     apps:["UX/UI systems","Product styling","Service design","Design research","Interaction design"],
@@ -213,6 +219,28 @@ const trends = [
 // Notes: location format = "City, State"; exams = [..]; mode ∈ {On-campus, Online, Dual Degree, Integrated}
 // Tiers are indicative: Tier 1 (IISc/IIT/IIITH/IIST/IISER/ISI/BITS/Top NITs/IIITs), Tier 2 (strong NITs/IIITs/leading privates), Tier 3 (good state/private colleges, especially TS/AP safety nets).
 const catalog = [
+  {trend:"econ-ds", tier:"Tier 1", course:"B.Sc (Hons) Economics (Minor: Data Science)",
+    inst:"IIM Bangalore — School of Multidisciplinary Studies", city:"Jigani (Bengaluru)", state:"Karnataka",
+    mode:"On-campus (residential)", duration:"4 years (3-year exit option)", fees:"₹8.5 lakh per year; need-based aid available",
+    exams:["IIMB UG Admissions Test"],
+    structure:["NEP-aligned economics core with data science & business studies", "Quantitative foundation (math/statistics + coding)", "Applied learning via research projects, internships, global immersion", "Choice of minors + custom pathways for specialisation", "Admissions 2025-26: Apply 14 Oct–20 Nov; Test 13 Dec; Interviews Jan; Offers 28 Feb"],
+    careers:["Economic/policy research","Analytics & data insights","Product/strategy analyst","Management/consulting internships","Prep for masters/PhD in economics or data"],
+    employers:["Career development with IIMB alumni mentorship network","Industry networking + guided placements"],
+    higher:["Masters/PhD in Economics","MS Data/Applied Stats","Public Policy/Development programs","MBA after work-ex"],
+    link:"https://www.iimb.ac.in/", 
+    mNote:"Small 80-seat inaugural cohort (40 per major) with personalised faculty attention."
+  },
+  {trend:"econ-ds", tier:"Tier 1", course:"B.Sc (Hons) Data Science (Minor: Economics)",
+    inst:"IIM Bangalore — School of Multidisciplinary Studies", city:"Jigani (Bengaluru)", state:"Karnataka",
+    mode:"On-campus (residential)", duration:"4 years (3-year exit option)", fees:"₹8.5 lakh per year; need-based aid available",
+    exams:["IIMB UG Admissions Test"],
+    structure:["Data science core with economics + business context", "Math/stats + computing for analytics & modelling", "Research projects, internships and global immersion for applied learning", "Customisable minors and pathways to match interests", "Admissions 2025-26: Apply 14 Oct–20 Nov; Test 13 Dec; Interviews Jan; Offers 28 Feb"],
+    careers:["Data scientist/analyst (entry)","Policy/impact analytics","Fintech & market research","Product/strategy analyst","Higher studies in data/quant fields"],
+    employers:["Career development with IIMB alumni mentorship network","Industry networking + guided placements"],
+    higher:["MS Data Science/Analytics","Masters in Economics/Finance","Public Policy/Development programs","MBA after work-ex"],
+    link:"https://www.iimb.ac.in/", 
+    mNote:"Residential programme on new Jigani campus; strong quantitative + interdisciplinary grounding."
+  },
   {trend:"ai-ml", tier:"Tier 1", course:"B.Tech in Artificial Intelligence",
     inst:"IIT Hyderabad (Dept. of AI)", city:"Hyderabad", state:"Telangana",
     mode:"On-campus", duration:"4 years", fees:"IIT norms",


### PR DESCRIPTION
## Summary
- add new Economics, Data & Business Studies trend to highlight IIM Bangalore UG initiative
- include detailed catalog entries for both B.Sc. (Hons) Economics and Data Science programmes with admissions and academic highlights

## Testing
- not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927a45d0220832194a2adfc06d83dcc)